### PR TITLE
latest flutter versions require kotlin 1.5.31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.walle.modal_progress_hud_nsn'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
I tried to use your Flutter module with a recent flutter version (version 3.0.1, android api 32) and got compiler error.
Being a flutter beginner myself (currently doing Angela Yus Flutter course where modal_progress_hud is suggested), I pointed it down to [this page(https://docs.flutter.dev/release/breaking-changes/kotlin-version) where flutter seems to require kotlin 1.5.31 upwards.

As your project had a smaller version number configured it was failing. I removed the kotlin version number and now it's compiling (I assume it falls back to the Kotlin version of the IDE?). I'm not sure this is the proper fix but at least it did it for me.